### PR TITLE
Local store handle deletes

### DIFF
--- a/expo/app/(app)/_layout.tsx
+++ b/expo/app/(app)/_layout.tsx
@@ -14,11 +14,13 @@ import { useGlobalStore } from "@/components/context/GlobalStoreContext";
 import { CanceledError } from "axios";
 import Ionicons from "@expo/vector-icons/Ionicons";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
+import { useMessageStore } from "@/components/context/MessageStoreContext";
 
 const AppLayout = () => {
   const { whoami } = useAuthUtils();
   const { getGroups, disconnect } = useWebSocket();
   const { store, refreshGroups } = useGlobalStore();
+  const { loadHistoricalMessages } = useMessageStore();
   const [user, setUser] = useState<User | undefined>(undefined);
   const [isLoading, setIsLoading] = useState(true);
   const insets = useSafeAreaInsets();
@@ -79,9 +81,13 @@ const AppLayout = () => {
   useEffect(() => {
     fetchGroups();
 
-    const intervalId = setInterval(fetchGroups, 5000);
+    const groupIntervalId = setInterval(fetchGroups, 5000);
+    const messagesIntervalId = setInterval(loadHistoricalMessages, 5000);
 
-    return () => clearInterval(intervalId);
+    return () => {
+      clearInterval(groupIntervalId);
+      clearInterval(messagesIntervalId);
+    };
   }, []);
 
   if (isLoading) {

--- a/expo/store/Store.native.ts
+++ b/expo/store/Store.native.ts
@@ -4,90 +4,171 @@ import type { GroupRow, IStore, MessageRow, UserRow } from "./types";
 import { Group, Message, User } from "@/types/types";
 
 export class Store implements IStore {
-  private db: SQLite.SQLiteDatabase | null;
+  private db: SQLite.SQLiteDatabase | null = null;
+  private initPromise: Promise<void>;
+  // Promise-based lock to serialize transaction-based operations
+  private transactionLock: Promise<void> = Promise.resolve();
+
   constructor() {
     this.db = SQLite.openDatabaseSync("store.db");
-    this.initDatabase();
+    this.initPromise = this._initializeDatabase();
   }
 
-  private async initDatabase() {
-    return new Promise<void>(async (resolve) => {
-      if (!this.db) throw new Error("Database not initialized");
-      const DATABASE_VERSION = 2;
-      let { user_version: currentDbVersion } = (await this.db.getFirstAsync<{
-        user_version: number;
-      }>("PRAGMA user_version")) || { user_version: -1 };
+  private async _initializeDatabase(): Promise<void> {
+    // ... (your existing _initializeDatabase code remains the same)
+    if (!this.db) {
+      throw new Error("Database not available for initialization.");
+    }
+    const DATABASE_VERSION = 3;
+    let { user_version: currentDbVersion } = (await this.db.getFirstAsync<{
+      user_version: number;
+    }>("PRAGMA user_version")) || { user_version: -1 };
 
-      if (currentDbVersion >= DATABASE_VERSION) {
-        resolve();
-        return;
+    if (currentDbVersion >= DATABASE_VERSION) return;
+
+    if (currentDbVersion < 1) {
+      await this.db.execAsync(`
+        PRAGMA journal_mode = 'wal';
+        PRAGMA foreign_keys = ON;
+        CREATE TABLE IF NOT EXISTS users (id INTEGER PRIMARY KEY NOT NULL, username TEXT, email TEXT, created_at TEXT, updated_at TEXT, group_admin_map TEXT);
+        CREATE TABLE IF NOT EXISTS groups (id INTEGER PRIMARY KEY NOT NULL, name TEXT, admin BOOLEAN DEFAULT FALSE, group_users TEXT NOT NULL DEFAULT '[]', created_at TEXT, updated_at TEXT);
+        CREATE TABLE IF NOT EXISTS messages (id INTEGER PRIMARY KEY NOT NULL, content TEXT NOT NULL, user_id INTEGER NOT NULL, group_id INTEGER NOT NULL, timestamp TEXT NOT NULL, FOREIGN KEY(group_id) REFERENCES groups(id), FOREIGN KEY(user_id) REFERENCES users(id));
+      `);
+      await this.db.execAsync(`PRAGMA user_version = 1`);
+      currentDbVersion = 1;
+    }
+    if (currentDbVersion === 1) {
+      await this.db.execAsync(`
+        ALTER TABLE groups ADD COLUMN start_time TEXT;
+        ALTER TABLE groups ADD COLUMN end_time TEXT;
+      `);
+      await this.db.execAsync(`PRAGMA user_version = 2`);
+      currentDbVersion = 2;
+    }
+    if (currentDbVersion === 2) {
+      await this.db.execAsync("BEGIN TRANSACTION;");
+      try {
+        await this.db.execAsync(
+          "ALTER TABLE messages RENAME TO messages_old_v2;"
+        );
+        await this.db.execAsync(`
+          CREATE TABLE messages (
+            id INTEGER PRIMARY KEY NOT NULL, content TEXT NOT NULL, user_id INTEGER NOT NULL,
+            group_id INTEGER NOT NULL, timestamp TEXT NOT NULL,
+            FOREIGN KEY(group_id) REFERENCES groups(id) ON DELETE CASCADE,
+            FOREIGN KEY(user_id) REFERENCES users(id)
+          );
+        `);
+        await this.db.execAsync(`
+          INSERT INTO messages (id, content, user_id, group_id, timestamp)
+          SELECT id, content, user_id, group_id, timestamp FROM messages_old_v2;
+        `);
+        await this.db.execAsync("DROP TABLE messages_old_v2;");
+        await this.db.execAsync("COMMIT;");
+        await this.db.execAsync(`PRAGMA user_version = ${DATABASE_VERSION}`);
+      } catch (e) {
+        await this.db.execAsync("ROLLBACK;");
+        console.error("Error migrating database to version 3:", e);
+        throw e;
       }
+    }
+  }
 
-      if (currentDbVersion < DATABASE_VERSION) {
-        if (currentDbVersion === 0) {
-          await this.db.execAsync(`
-            PRAGMA journal_mode = 'wal';
-            PRAGMA foreign_keys = ON;
-            CREATE TABLE IF NOT EXISTS users (id INTEGER PRIMARY KEY NOT NULL, username TEXT, email TEXT, created_at TEXT, updated_at TEXT, group_admin_map TEXT);
-            CREATE TABLE IF NOT EXISTS groups (id INTEGER PRIMARY KEY NOT NULL, name TEXT, admin BOOLEAN DEFAULT FALSE, group_users TEXT NOT NULL DEFAULT '[]', created_at TEXT, updated_at TEXT);
-            CREATE TABLE IF NOT EXISTS messages (id INTEGER PRIMARY KEY NOT NULL, content TEXT NOT NULL, user_id INTEGER NOT NULL, group_id INTEGER NOT NULL, timestamp TEXT NOT NULL, FOREIGN KEY(group_id) REFERENCES groups(id), FOREIGN KEY(user_id) REFERENCES users(id));
-          `);
+  private async getDb(): Promise<SQLite.SQLiteDatabase> {
+    await this.initPromise;
+    if (!this.db) {
+      throw new Error("Database not initialized or initialization failed.");
+    }
+    return this.db;
+  }
 
-          currentDbVersion = 1;
-          await this.db.execAsync(`PRAGMA user_version = 1`); // Set to 1
+  /**
+   * Executes a given operation within a database transaction, ensuring
+   * that only one such operation runs at a time using a lock.
+   */
+  public async performSerialTransaction<T>(
+    operation: (db: SQLite.SQLiteDatabase) => Promise<T>
+  ): Promise<T> {
+    const db = await this.getDb();
+
+    let releaseLock = () => {};
+    const currentLockExecution = this.transactionLock.then(async () => {
+      // console.log("Lock acquired, beginning transaction for operation.");
+      await db.execAsync("BEGIN TRANSACTION;");
+      try {
+        const result = await operation(db);
+        await db.execAsync("COMMIT;");
+        // console.log("Transaction committed.");
+        return result;
+      } catch (error) {
+        console.error(
+          "Error during serial transaction operation, attempting rollback:",
+          error
+        );
+        try {
+          await db.execAsync("ROLLBACK;");
+          // console.log("Transaction rolled back.");
+        } catch (rollbackError) {
+          console.error("Failed to rollback transaction:", rollbackError);
         }
-
-        if (currentDbVersion === 1) {
-          await this.db.execAsync(`
-            ALTER TABLE groups ADD COLUMN start_time TEXT;
-            ALTER TABLE groups ADD COLUMN end_time TEXT;
-          `);
-          currentDbVersion = 2;
-          await this.db.execAsync(`PRAGMA user_version = ${DATABASE_VERSION}`);
-        }
-        resolve();
+        throw error;
       }
-
-      resolve();
     });
-  }
 
-  async saveMessages(messages: Message[]): Promise<void> {
-    if (!this.db) throw new Error("Database not initialized");
+    this.transactionLock = currentLockExecution
+      .catch(() => {})
+      .then(() => {
+        releaseLock();
+      });
+    const lockReleasedPromise = new Promise<void>((resolve) => {
+      releaseLock = resolve;
+    });
 
     try {
-      const users = [...new Set(messages.map((msg) => msg.user))];
+      return await currentLockExecution;
+    } finally {
+    }
+  }
 
-      const group_ids = [...new Set(messages.map((msg) => msg.group_id))];
-
-      const real_groups = await this.db.getAllAsync<{ id: number }>(
-        `SELECT DISTINCT(id) FROM groups;`
-      );
-
-      const real_group_ids = real_groups.map((group) => group.id);
-
-      const diff = group_ids.filter((id) => !real_group_ids.includes(id));
-
-      for (const user of users) {
-        await this.db.runAsync(
-          `INSERT INTO users (id, username) VALUES (?, ?)
-         ON CONFLICT(id) DO UPDATE SET username = excluded.username;`,
-          [user.id, user.username]
-        );
+  async saveMessages(
+    messagesToSave: Message[],
+    clearFirst: boolean = false
+  ): Promise<void> {
+    return this.performSerialTransaction(async (db) => {
+      if (clearFirst) {
+        await db.runAsync("DELETE FROM messages;");
       }
 
-      for (const id of diff) {
-        await this.db.runAsync(
-          `INSERT INTO groups (id) VALUES (?)
-         ON CONFLICT(id) DO NOTHING;`,
+      const users = Array.from(new Set(messagesToSave.map((msg) => msg.user)));
+      const group_ids = [...new Set(messagesToSave.map((msg) => msg.group_id))];
+
+      const real_groups = await db.getAllAsync<{ id: number }>(
+        `SELECT DISTINCT(id) FROM groups;`
+      );
+      const real_group_ids = real_groups.map((group) => group.id);
+      const diff_group_ids = group_ids.filter(
+        (id) => !real_group_ids.includes(id)
+      );
+
+      for (const user of users) {
+        if (user && typeof user.id !== "undefined" && user.username) {
+          await db.runAsync(
+            `INSERT INTO users (id, username) VALUES (?, ?)
+             ON CONFLICT(id) DO UPDATE SET username = excluded.username;`,
+            [user.id, user.username]
+          );
+        }
+      }
+      for (const id of diff_group_ids) {
+        await db.runAsync(
+          `INSERT INTO groups (id) VALUES (?) ON CONFLICT(id) DO NOTHING;`,
           [id]
         );
       }
-
-      for (const message of messages) {
-        await this.db.runAsync(
+      for (const message of messagesToSave) {
+        await db.runAsync(
           `INSERT OR REPLACE INTO messages (id, content, user_id, group_id, timestamp)
-         VALUES (?, ?, ?, ?, ?)`,
+           VALUES (?, ?, ?, ?, ?)`,
           [
             message.id,
             message.content,
@@ -97,73 +178,120 @@ export class Store implements IStore {
           ]
         );
       }
-    } catch (error) {
-      console.error(error);
-    }
+    });
   }
 
-  async loadMessages(): Promise<Message[]> {
-    if (!this.db) throw new Error("Database not initialized");
+  async saveGroups(
+    groupsToSave: Group[],
+    clearFirstAndPrune: boolean = true
+  ): Promise<void> {
+    return this.performSerialTransaction(async (db) => {
+      const incomingGroupIds = groupsToSave.map((group) => group.id);
 
-    const result = await this.db.getAllAsync<MessageRow>(`
-        SELECT m.id as message_id, m.content AS content, m.group_id AS group_id, u.id AS user_id, u.username AS username, m.timestamp AS timestamp FROM messages AS m 
-        INNER JOIN users AS u ON u.id = m.user_id`);
+      for (const group of groupsToSave) {
+        await db.runAsync(
+          `INSERT INTO groups (id, name, admin, group_users, created_at, updated_at, start_time, end_time)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+           ON CONFLICT(id) DO UPDATE SET
+             name = excluded.name, admin = excluded.admin, group_users = excluded.group_users,
+             created_at = excluded.created_at, updated_at = excluded.updated_at,
+             start_time = excluded.start_time, end_time = excluded.end_time;`,
+          [
+            group.id,
+            group.name,
+            group.admin ? 1 : 0,
+            JSON.stringify(group.group_users || []),
+            group.created_at,
+            group.updated_at,
+            group.start_time,
+            group.end_time,
+          ]
+        );
+      }
 
-    return (
-      result?.map((row) => {
-        return {
-          id: row.message_id,
-          content: row.content,
-          group_id: row.group_id,
-          user: {
-            id: row.user_id,
-            username: row.username,
-          },
-          timestamp: row.timestamp,
-        };
-      }) ?? []
-    );
+      if (clearFirstAndPrune) {
+        if (incomingGroupIds.length > 0) {
+          const placeholders = incomingGroupIds.map(() => "?").join(",");
+          await db.runAsync(
+            `DELETE FROM groups WHERE id NOT IN (${placeholders});`,
+            incomingGroupIds
+          );
+        } else {
+          await db.runAsync("DELETE FROM groups;"); // No incoming groups, delete all
+        }
+      }
+    });
+  }
+
+  async saveUsers(usersToSave: User[]): Promise<void> {
+    return this.performSerialTransaction(async (db) => {
+      for (const user of usersToSave) {
+        await db.runAsync(
+          `INSERT OR REPLACE INTO users (id, username, email, created_at, updated_at, group_admin_map)
+           VALUES (?, ?, ?, ?, ?, ?)`,
+          [
+            user.id,
+            user.username,
+            user.email,
+            user.created_at,
+            user.updated_at,
+            JSON.stringify(user.group_admin_map ?? {}),
+          ]
+        );
+      }
+    });
   }
 
   async clearMessages(): Promise<void> {
-    if (!this.db) throw new Error("Database not initialized");
-
-    await this.db.runAsync("DELETE FROM messages;");
+    const db = await this.getDb();
+    await db.runAsync("DELETE FROM messages;");
+  }
+  async clearGroups(): Promise<void> {
+    const db = await this.getDb();
+    await db.runAsync("DELETE FROM groups;");
+  }
+  async clearUsers(): Promise<void> {
+    const db = await this.getDb();
+    await db.runAsync("DELETE FROM users;");
   }
 
-  async saveGroups(groups: Group[]): Promise<void> {
-    if (!this.db) throw new Error("Database not initialized");
-
-    for (const group of groups) {
-      await this.db.runAsync(
-        `INSERT INTO groups (id, name, admin, group_users, created_at, updated_at, start_time, end_time)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?)
-       ON CONFLICT(id) DO UPDATE SET name = excluded.name, admin = excluded.admin, group_users = excluded.group_users, created_at = excluded.created_at, updated_at = excluded.updated_at, start_time = excluded.start_time, end_time = excluded.end_time;`,
-        [
-          group.id,
-          group.name,
-          group.admin,
-          JSON.stringify(group.group_users),
-          group.created_at,
-          group.updated_at,
-          group.start_time,
-          group.end_time,
-        ]
-      );
-    }
+  async loadMessages(): Promise<Message[]> {
+    const db = await this.getDb();
+    const result = await db.getAllAsync<MessageRow>(`
+      SELECT m.id as message_id, m.content AS content, m.group_id AS group_id,
+             u.id AS user_id, u.username AS username, m.timestamp AS timestamp
+      FROM messages AS m
+      INNER JOIN users AS u ON u.id = m.user_id
+    `);
+    return (
+      result?.map((row) => ({
+        id: row.message_id,
+        content: row.content,
+        group_id: row.group_id,
+        user: {
+          id: row.user_id,
+          username: row.username,
+        },
+        timestamp: row.timestamp,
+      })) ?? []
+    );
   }
-
   async loadGroups(): Promise<Group[]> {
-    if (!this.db) throw new Error("Database not initialized");
-    const result = await this.db.getAllAsync<GroupRow>(`
-        SELECT * FROM groups;`);
+    const db = await this.getDb();
+    const result = await db.getAllAsync<GroupRow>(`SELECT * FROM groups;`);
     return (
       result?.map((row) => {
+        let parsedGroupUsers;
+        try {
+          parsedGroupUsers = JSON.parse(JSON.parse(row.group_users));
+        } catch (e) {
+          parsedGroupUsers = [];
+        }
         return {
           id: row.id,
           name: row.name,
-          admin: row.admin,
-          group_users: JSON.parse(JSON.parse(row.group_users)),
+          admin: !!row.admin,
+          group_users: parsedGroupUsers,
           created_at: row.created_at,
           updated_at: row.updated_at,
           start_time: row.start_time,
@@ -172,43 +300,16 @@ export class Store implements IStore {
       }) ?? []
     );
   }
-
-  async clearGroups(): Promise<void> {
-    if (!this.db) throw new Error("Database not initialized");
-    await this.db.runAsync("DELETE FROM groups;");
-  }
-
-  async saveUsers(users: User[]): Promise<void> {
-    if (!this.db) throw new Error("Database not initialized");
-
-    for (const user of users) {
-      await this.db.runAsync(
-        `INSERT OR REPLACE INTO users (id, username, email, created_at, updated_at, group_admin_map)
-       VALUES (?, ?, ?, ?, ?, ?)`,
-        [
-          user.id,
-          user.username,
-          user.email,
-          user.created_at,
-          user.updated_at,
-          JSON.stringify(user.group_admin_map),
-        ]
-      );
-    }
-  }
-
   async loadUsers(): Promise<User[]> {
-    if (!this.db) throw new Error("Database not initialized");
-    const result = await this.db.getAllAsync<UserRow>(`
-        SELECT * FROM users;`);
+    const db = await this.getDb();
+    const result = await db.getAllAsync<UserRow>(`SELECT * FROM users;`);
     return (
       result?.map((row) => {
-        var group_admin_map;
+        let group_admin_map;
         try {
-          group_admin_map = JSON.parse(row.group_admin_map ?? "[]");
+          group_admin_map = JSON.parse(row.group_admin_map ?? "{}");
         } catch (error) {
-          console.error(error);
-          group_admin_map = [];
+          group_admin_map = {};
         }
         return {
           id: row.id,
@@ -222,15 +323,26 @@ export class Store implements IStore {
     );
   }
 
-  async clearUsers(): Promise<void> {
-    if (!this.db) throw new Error("Database not initialized");
-    await this.db.runAsync("DELETE FROM users;");
-  }
-
   async close(): Promise<void> {
+    try {
+      await this.initPromise;
+      await this.transactionLock;
+    } catch (error) {
+      console.warn(
+        "Error during pre-close waits (init or transaction lock):",
+        error
+      );
+    }
+
     if (this.db) {
-      await this.db.closeAsync();
-      this.db = null;
+      try {
+        await this.db.closeAsync();
+        console.log("Database closed successfully.");
+      } catch (closeError) {
+        console.error("Error closing database:", closeError);
+      } finally {
+        this.db = null;
+      }
     }
   }
 }

--- a/expo/store/Store.web.ts
+++ b/expo/store/Store.web.ts
@@ -17,22 +17,21 @@ export class Store implements IStore {
     clearFirst: boolean = false
   ): Promise<void> {
     if (clearFirst) {
-      this.messages = [...messagesToSave]; // Replace all, ensure it's a new array
+      this.messages = [...messagesToSave];
       return;
     }
 
-    // Merge logic: update existing, add new
     const messageMap = new Map<number, Message>(
       this.messages.map((m) => [m.id, m])
     );
     for (const message of messagesToSave) {
-      messageMap.set(message.id, message); // Add or update
+      messageMap.set(message.id, message);
     }
     this.messages = Array.from(messageMap.values());
   }
 
   async loadMessages(): Promise<Message[]> {
-    return this.messages.map((message) => ({ ...message })); // Return a copy
+    return this.messages.map((message) => ({ ...message }));
   }
 
   async clearMessages(): Promise<void> {

--- a/expo/store/Store.web.ts
+++ b/expo/store/Store.web.ts
@@ -1,5 +1,11 @@
 import type { IStore } from "./types";
-import type { Group, Message, User } from "@/types/types";
+import type {
+  Group,
+  Message,
+  User,
+  GroupUser,
+  GroupAdminMap,
+} from "@/types/types";
 
 export class Store implements IStore {
   private messages: Message[] = [];
@@ -7,14 +13,19 @@ export class Store implements IStore {
   private users: User[] = [];
 
   async saveMessages(messages: Message[]): Promise<void> {
-    const uniqueMessages = [...this.messages, ...messages].filter(
-      (item, pos, self) => self.findIndex((m) => m.id === item.id) === pos
-    );
-    this.messages = uniqueMessages;
+    const existingMessageIds = new Set(this.messages.map((m) => m.id));
+    const newMessages = messages.filter((m) => !existingMessageIds.has(m.id));
+
+    this.messages = this.messages
+      .map((existingMsg) => {
+        const updatedMsg = messages.find((m) => m.id === existingMsg.id);
+        return updatedMsg || existingMsg;
+      })
+      .concat(newMessages);
   }
 
   async loadMessages(): Promise<Message[]> {
-    return this.messages;
+    return [...this.messages];
   }
 
   async clearMessages(): Promise<void> {
@@ -23,12 +34,30 @@ export class Store implements IStore {
 
   async saveGroups(groups: Group[]): Promise<void> {
     this.groups = groups.map((group) => {
-      return { ...group, group_users: JSON.parse(`${group.group_users}`) };
+      let parsedGroupUsers: GroupUser[] = [];
+      if (typeof group.group_users === "string") {
+        try {
+          parsedGroupUsers = JSON.parse(group.group_users);
+        } catch (e) {
+          console.error(
+            `Error parsing group.group_users in Store.web.ts. Input: '${group.group_users}'`,
+            e
+          );
+        }
+      } else if (Array.isArray(group.group_users)) {
+        parsedGroupUsers = group.group_users;
+      } else if (group.group_users) {
+        console.warn(
+          `group.group_users in Store.web.ts was an unexpected type: ${typeof group.group_users}. Input:`,
+          group.group_users
+        );
+      }
+      return { ...group, group_users: parsedGroupUsers };
     });
   }
 
   async loadGroups(): Promise<Group[]> {
-    return this.groups;
+    return this.groups.map((group) => ({ ...group }));
   }
 
   async clearGroups(): Promise<void> {
@@ -37,15 +66,83 @@ export class Store implements IStore {
 
   async saveUsers(users: User[]): Promise<void> {
     this.users = users.map((user) => {
-      return {
-        ...user,
-        group_admin_map: JSON.parse(`${user.group_admin_map}`) ?? {},
-      };
+      let finalGroupAdminMap: GroupAdminMap | undefined = undefined;
+
+      const sourceMapData = user.group_admin_map;
+
+      if (typeof sourceMapData === "string") {
+        try {
+          const parsedJson = JSON.parse(sourceMapData);
+          if (
+            typeof parsedJson === "object" &&
+            parsedJson !== null &&
+            !Array.isArray(parsedJson)
+          ) {
+            finalGroupAdminMap = new Map<number, boolean>();
+            for (const key in parsedJson) {
+              if (Object.prototype.hasOwnProperty.call(parsedJson, key)) {
+                const numKey = Number(key);
+                if (!isNaN(numKey) && typeof parsedJson[key] === "boolean") {
+                  finalGroupAdminMap.set(numKey, parsedJson[key]);
+                } else {
+                  console.warn(
+                    `Invalid key-value pair in parsed group_admin_map for user ${user.id}: key='${key}', value='${parsedJson[key]}'`
+                  );
+                }
+              }
+            }
+          } else {
+            console.warn(
+              `user.group_admin_map string for user ${user.id} did not parse to a map-like object:`,
+              sourceMapData
+            );
+          }
+        } catch (e) {
+          console.error(
+            `Error parsing user.group_admin_map string for user ${user.id}: '${sourceMapData}'`,
+            e
+          );
+        }
+      } else if (sourceMapData instanceof Map) {
+        finalGroupAdminMap = sourceMapData;
+      } else if (
+        typeof sourceMapData === "object" &&
+        sourceMapData !== null &&
+        !Array.isArray(sourceMapData)
+      ) {
+        finalGroupAdminMap = new Map<number, boolean>();
+        const plainObjectSource = sourceMapData as Record<string, unknown>; // Type assertion
+        for (const key in plainObjectSource) {
+          if (Object.prototype.hasOwnProperty.call(plainObjectSource, key)) {
+            const numKey = Number(key);
+            const value = plainObjectSource[key]; // value is unknown here
+            if (!isNaN(numKey) && typeof value === "boolean") {
+              finalGroupAdminMap.set(numKey, value);
+            } else {
+              console.warn(
+                `Invalid key-value pair in object group_admin_map for user ${user.id}: key='${key}', value='${value}'`
+              );
+            }
+          }
+        }
+      } else if (
+        sourceMapData === null ||
+        typeof sourceMapData === "undefined"
+      ) {
+        finalGroupAdminMap = undefined;
+      } else {
+        console.warn(
+          `user.group_admin_map for user ${user.id} was an unexpected type: ${typeof sourceMapData}`,
+          sourceMapData
+        );
+      }
+
+      return { ...user, group_admin_map: finalGroupAdminMap };
     });
   }
 
   async loadUsers(): Promise<User[]> {
-    return this.users;
+    return this.users.map((user) => ({ ...user }));
   }
 
   async clearUsers(): Promise<void> {

--- a/expo/store/types.ts
+++ b/expo/store/types.ts
@@ -1,13 +1,37 @@
 import { Group, Message, User } from "@/types/types";
 
 export interface IStore {
-  saveMessages(messages: Message[]): Promise<void>;
+  /**
+   * Saves an array of messages.
+   * @param messages The messages to save.
+   * @param clearFirst If true, existing messages will be cleared before saving the new ones.
+   *                   Otherwise, messages are typically upserted or merged.
+   */
+  saveMessages(messages: Message[], clearFirst?: boolean): Promise<void>;
+
   loadMessages(): Promise<Message[]>;
   clearMessages(): Promise<void>;
-  saveGroups(groups: Group[]): Promise<void>;
+
+  /**
+   * Saves an array of groups.
+   * @param groups The groups to save.
+   * @param clearFirstAndPrune If true, existing groups not in the provided array may be removed,
+   *                           and the provided groups will replace/update existing ones.
+   *                           If false, groups are typically upserted without removing others.
+   */
+  saveGroups(groups: Group[], clearFirstAndPrune?: boolean): Promise<void>;
+
   loadGroups(): Promise<Group[]>;
   clearGroups(): Promise<void>;
-  saveUsers(users: User[]): Promise<void>;
+
+  /**
+   * Saves an array of users.
+   * @param users The users to save.
+   * @param clearFirstAndPrune (Optional consideration for future) If true, existing users not in the
+   *                           provided array might be removed.
+   */
+  saveUsers(users: User[] /*, clearFirstAndPrune?: boolean */): Promise<void>;
+
   loadUsers(): Promise<User[]>;
   clearUsers(): Promise<void>;
   close(): Promise<void>;


### PR DESCRIPTION
**I. Core Problem: Handling Deleted/Removed Groups and Messages (`Store.native.ts`)**

1.  **Database Schema Migration for Cascading Deletes:**
    *   Incremented `DATABASE_VERSION` to `3`.
    *   Added a migration step to alter the `messages` table:
        *   Renamed the old `messages` table.
        *   Created a new `messages` table with `FOREIGN KEY(group_id) REFERENCES groups(id) ON DELETE CASCADE`.
        *   Copied data from the old table to the new one.
        *   Dropped the old table.
    *   This ensures that when a group is deleted from the `groups` table, all associated messages are automatically removed by SQLite.

2.  **Improved `saveGroups` Logic for Pruning:**
    *   The `saveGroups` method (now using `performSerialTransaction`) was updated to:
        *   Upsert all incoming groups.
        *   Delete local groups that are *not* present in the list of incoming group IDs. This keeps the local cache synchronized with the server's state of which groups the user belongs to.

**II. Preventing Concurrent Transaction Errors (`Store.native.ts`)**

1.  **Serialized Transactions (`performSerialTransaction`):**
    *   Introduced a `transactionLock` (a promise chain) in the `Store` class.
    *   Created a `public async performSerialTransaction<T>(operation: (db: SQLite.SQLiteDatabase) => Promise<T>): Promise<T>` method.
    *   This method wraps database operations in `BEGIN TRANSACTION`, `COMMIT`, and `ROLLBACK`.
    *   It ensures that only one such transactional operation runs at a time by making subsequent calls wait for the current one to complete via the `transactionLock`.
    *   All major data-saving methods (`saveMessages`, `saveGroups`, `saveUsers`) were refactored to use `performSerialTransaction` to execute their database logic atomically and serially. This resolved errors like "cannot start a transaction within a transaction" and "cannot rollback - no transaction is active."

**III. Correcting Data Handling and Type Issues**

1.  **JSON Parsing for `group_users` and `group_admin_map`:**
    *   **`Store.native.ts`:**
        *   The `saveGroups` method's `JSON.stringify(group.group_users)` (where `group.group_users` is already a string) correctly results in a double-stringified JSON string being stored in SQLite.
        *   The `loadGroups` method's `JSON.parse(JSON.parse(row.group_users))` correctly handles this double-stringification to retrieve the actual JavaScript array.
    *   **`Store.web.ts`:**
        *   Initially, there was confusion about how many times to parse. We clarified that since the web store receives the JSON string directly from the server, it only needs a single `JSON.parse()` for fields like `group_users`.
        *   The `saveGroups` method was updated to parse `group.group_users` (if it's a string) once to get the `GroupUser[]`.
        *   The `saveUsers` method was updated to parse `user.group_admin_map` (if it's a string) into a plain object, and then convert that plain object into a `new Map<number, boolean>()` to match the `GroupAdminMap` type. This involved handling potential type errors during iteration using type assertions (`as Record<string, unknown>`) for `for...in` loops.

2.  **Type Safety in `Store.web.ts`:**
    *   Corrected the type of `parsedGroupUsers` in `saveGroups` from `User[]` to `GroupUser[]` to match the actual structure of the data (which includes an `admin` property per user within the group context).
    *   Addressed type errors in `saveUsers` related to `group_admin_map` by ensuring the final stored value is a `Map<number, boolean> | undefined`, matching the `User` type's definition. This involved converting parsed JSON objects into `Map` instances.
    *   `load` methods in `Store.web.ts` were updated to return shallow copies of data to prevent direct external mutation.

**IV. Asynchronous Initialization and Re-entrancy Guards**

1.  **Store Initialization (`Store.native.ts`):**
    *   Refactored the `Store` constructor and `_initializeDatabase` to ensure database initialization (`initPromise`) is properly awaited before any database operations are performed, using a `getDb()` helper method.
2.  **Re-entrancy Guard in React Context (`MessageStoreContext.tsx`):**
    *   Maintained the `isSyncingHistoricalMessagesRef` in your `loadHistoricalMessages` function. This prevents multiple concurrent *network requests and top-level sync operations* if one is already in progress, complementing the database-level transaction serialization.

**V. General Code Refinements**

*   Improved error handling and console logging in various places.
*   Addressed TypeScript compiler errors related to type mismatches and iteration over objects.
*   Clarified the data flow from the Go backend (specifically the `::text` casting for JSON fields) and how it impacts parsing on the frontend.