### PR TITLE
Fix settings test: use setItem("false") when disabling push notifications

### DIFF
--- a/expo/app/(app)/settings.tsx
+++ b/expo/app/(app)/settings.tsx
@@ -200,7 +200,7 @@ export default function SettingsScreen() {
             return;
           }
           try {
-            await AsyncStorage.removeItem(SETTINGS_PUSH_ENABLED_KEY);
+            await AsyncStorage.setItem(SETTINGS_PUSH_ENABLED_KEY, "false");
             setIsPushEnabled(false);
           } catch (storageError) {
             console.error("Failed to persist push disabled state:", storageError);


### PR DESCRIPTION
## Summary
- Replaces `AsyncStorage.removeItem(SETTINGS_PUSH_ENABLED_KEY)` with `AsyncStorage.setItem(SETTINGS_PUSH_ENABLED_KEY, "false")` in the disable-push path
- Makes the disable path symmetric with the enable path (`setItem("true")`)
- Fixes the failing `SettingsScreen › disables push notifications and persists preference` test

## Test plan
- [ ] Run `__tests__/app/settings.test.tsx` — all tests should pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved persistence of push notification settings to ensure the disabled state is reliably saved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->