### PR TITLE
Debounce signup form validation errors

### DIFF
--- a/expo/components/AuthMenu/SignupForm.test.tsx
+++ b/expo/components/AuthMenu/SignupForm.test.tsx
@@ -150,6 +150,92 @@ describe("SignupForm", () => {
     });
   });
 
+  describe("debounced validation errors", () => {
+    beforeEach(() => {
+      jest.useFakeTimers();
+    });
+
+    afterEach(() => {
+      jest.useRealTimers();
+    });
+
+    it("does not show email error immediately after typing an invalid email", () => {
+      const { getByPlaceholderText, queryByText } = render(<SignupForm />);
+      fireEvent.changeText(getByPlaceholderText("Enter your email"), "notanemail");
+      expect(queryByText("Please enter a valid email address")).toBeNull();
+    });
+
+    it("shows email error after the debounce delay", () => {
+      const { getByPlaceholderText, queryByText } = render(<SignupForm />);
+      fireEvent.changeText(getByPlaceholderText("Enter your email"), "notanemail");
+      act(() => { jest.advanceTimersByTime(1500); });
+      expect(queryByText("Please enter a valid email address")).toBeTruthy();
+    });
+
+    it("hides email error immediately when email becomes valid", () => {
+      const { getByPlaceholderText, queryByText } = render(<SignupForm />);
+      fireEvent.changeText(getByPlaceholderText("Enter your email"), "notanemail");
+      act(() => { jest.advanceTimersByTime(1500); });
+      expect(queryByText("Please enter a valid email address")).toBeTruthy();
+
+      fireEvent.changeText(getByPlaceholderText("Enter your email"), "valid@example.com");
+      expect(queryByText("Please enter a valid email address")).toBeNull();
+    });
+
+    it("does not show username error immediately after typing a blank username", () => {
+      const { getByPlaceholderText, queryByText } = render(<SignupForm />);
+      fireEvent.changeText(getByPlaceholderText("Choose a username"), "  ");
+      expect(queryByText(/Username cannot be blank/)).toBeNull();
+    });
+
+    it("shows username error after the debounce delay", () => {
+      const { getByPlaceholderText, queryByText } = render(<SignupForm />);
+      fireEvent.changeText(getByPlaceholderText("Choose a username"), "  ");
+      act(() => { jest.advanceTimersByTime(1500); });
+      expect(queryByText(/Username cannot be blank/)).toBeTruthy();
+    });
+
+    it("does not show password error immediately after typing a short password", () => {
+      const { getByPlaceholderText, queryByText } = render(<SignupForm />);
+      fireEvent.changeText(getByPlaceholderText("Create a password (min 8 characters)"), "short");
+      expect(queryByText(/Password must be/)).toBeNull();
+    });
+
+    it("shows password error after the debounce delay", () => {
+      const { getByPlaceholderText, queryByText } = render(<SignupForm />);
+      fireEvent.changeText(getByPlaceholderText("Create a password (min 8 characters)"), "short");
+      act(() => { jest.advanceTimersByTime(1500); });
+      expect(queryByText(/Password must be/)).toBeTruthy();
+    });
+
+    it("does not show error if user corrects field before delay elapses", () => {
+      const { getByPlaceholderText, queryByText } = render(<SignupForm />);
+      fireEvent.changeText(getByPlaceholderText("Enter your email"), "notanemail");
+      act(() => { jest.advanceTimersByTime(1000); });
+      fireEvent.changeText(getByPlaceholderText("Enter your email"), "valid@example.com");
+      act(() => { jest.advanceTimersByTime(1500); });
+      expect(queryByText("Please enter a valid email address")).toBeNull();
+    });
+
+    it("does not show error immediately after clearing and retyping invalid input", () => {
+      const { getByPlaceholderText, queryByText } = render(<SignupForm />);
+      // Type invalid, let debounce settle so debouncedEmail is non-empty
+      fireEvent.changeText(getByPlaceholderText("Enter your email"), "notanemail");
+      act(() => { jest.advanceTimersByTime(1500); });
+      expect(queryByText("Please enter a valid email address")).toBeTruthy();
+
+      // Clear field, then immediately retype invalid input before debounce fires
+      fireEvent.changeText(getByPlaceholderText("Enter your email"), "");
+      fireEvent.changeText(getByPlaceholderText("Enter your email"), "alsoinvalid");
+      // Error should not show yet — debounce hasn't caught up to new value
+      expect(queryByText("Please enter a valid email address")).toBeNull();
+
+      // After debounce settles, error shows again
+      act(() => { jest.advanceTimersByTime(1500); });
+      expect(queryByText("Please enter a valid email address")).toBeTruthy();
+    });
+  });
+
   describe("form submission", () => {
     function fillAndSubmit(
       utils: ReturnType<typeof render>,

--- a/expo/components/AuthMenu/SignupForm.tsx
+++ b/expo/components/AuthMenu/SignupForm.tsx
@@ -2,6 +2,7 @@ import DateTimePicker from "@react-native-community/datetimepicker";
 import { isAxiosError } from "axios";
 import { useState } from "react";
 import { Pressable, Text, TextInput, View } from "react-native";
+import { useDebounce } from "@/hooks/useDebounce";
 import { useAuthUtils } from "../context/AuthUtilsContext";
 import Button from "../Global/Button/Button";
 
@@ -38,6 +39,10 @@ export default function SignupForm() {
   const [showPicker, setShowPicker] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+
+  const debouncedEmail = useDebounce(email, 1500);
+  const debouncedUsername = useDebounce(username, 1500);
+  const debouncedPassword = useDebounce(password, 1500);
 
   const isUsernameValid = username.trim().length > 0 && username.trim().length <= MAX_USERNAME_LENGTH;
   const isEmailValid = email.trim().length > 0 && EMAIL_REGEX.test(email.trim()) && email.trim().length <= MAX_EMAIL_LENGTH;
@@ -85,7 +90,7 @@ export default function SignupForm() {
             onChangeText={setEmail}
             value={email}
           />
-          {email.length > 0 && !isEmailValid && (
+          {email.length > 0 && debouncedEmail === email && !isEmailValid && (
             <Text className="text-amber-500 text-xs mt-1">
               Please enter a valid email address
             </Text>
@@ -105,7 +110,7 @@ export default function SignupForm() {
             value={username}
             maxLength={MAX_USERNAME_LENGTH}
           />
-          {username.length > 0 && !isUsernameValid && (
+          {username.length > 0 && debouncedUsername === username && !isUsernameValid && (
             <Text className="text-amber-500 text-xs mt-1">
               Username cannot be blank or exceed {MAX_USERNAME_LENGTH} characters
             </Text>
@@ -126,7 +131,7 @@ export default function SignupForm() {
             value={password}
             maxLength={MAX_PASSWORD_LENGTH}
           />
-          {password.length > 0 && !isPasswordValid && (
+          {password.length > 0 && debouncedPassword === password && !isPasswordValid && (
             <Text className="text-amber-500 text-xs mt-1">
               Password must be {MIN_PASSWORD_LENGTH}-{MAX_PASSWORD_LENGTH} characters
             </Text>

--- a/expo/hooks/useDebounce.test.ts
+++ b/expo/hooks/useDebounce.test.ts
@@ -1,0 +1,67 @@
+import { renderHook, act } from "@testing-library/react-native";
+import { useDebounce } from "./useDebounce";
+
+describe("useDebounce", () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it("returns the initial value immediately", () => {
+    const { result } = renderHook(() => useDebounce("hello", 500));
+    expect(result.current).toBe("hello");
+  });
+
+  it("does not update before the delay has elapsed", () => {
+    const { result, rerender } = renderHook(
+      ({ value }: { value: string }) => useDebounce(value, 500),
+      { initialProps: { value: "initial" } },
+    );
+
+    rerender({ value: "updated" });
+    act(() => { jest.advanceTimersByTime(499); });
+    expect(result.current).toBe("initial");
+  });
+
+  it("updates after the delay has elapsed", () => {
+    const { result, rerender } = renderHook(
+      ({ value }: { value: string }) => useDebounce(value, 500),
+      { initialProps: { value: "initial" } },
+    );
+
+    rerender({ value: "updated" });
+    act(() => { jest.advanceTimersByTime(500); });
+    expect(result.current).toBe("updated");
+  });
+
+  it("resets the timer when value changes before delay elapses", () => {
+    const { result, rerender } = renderHook(
+      ({ value }: { value: string }) => useDebounce(value, 500),
+      { initialProps: { value: "initial" } },
+    );
+
+    rerender({ value: "first" });
+    act(() => { jest.advanceTimersByTime(300); });
+    rerender({ value: "second" });
+    act(() => { jest.advanceTimersByTime(300); });
+    // 300ms since last change — not yet at 500ms
+    expect(result.current).toBe("initial");
+
+    act(() => { jest.advanceTimersByTime(200); });
+    expect(result.current).toBe("second");
+  });
+
+  it("works with non-string types", () => {
+    const { result, rerender } = renderHook(
+      ({ value }: { value: number }) => useDebounce(value, 300),
+      { initialProps: { value: 1 } },
+    );
+
+    rerender({ value: 42 });
+    act(() => { jest.advanceTimersByTime(300); });
+    expect(result.current).toBe(42);
+  });
+});

--- a/expo/hooks/useDebounce.ts
+++ b/expo/hooks/useDebounce.ts
@@ -1,0 +1,12 @@
+import { useEffect, useState } from "react";
+
+export function useDebounce<T>(value: T, delay: number): T {
+  const [debounced, setDebounced] = useState<T>(value);
+
+  useEffect(() => {
+    const t = setTimeout(() => setDebounced(value), delay);
+    return () => clearTimeout(t);
+  }, [value, delay]);
+
+  return debounced;
+}


### PR DESCRIPTION
## Summary
- Adds a generic `useDebounce<T>(value, delay)` hook at `expo/hooks/useDebounce.ts`
- Delays inline validation error messages on the signup form (email, username, password) until the user has stopped typing for 1.5s
- Errors clear immediately when the field becomes valid
- Uses `value === debouncedValue` as the settled check — cleaner than a length guard and correctly handles the clear-then-retype edge case

## Test plan
- [ ] `useDebounce` unit tests: initial value, pre-delay no-update, post-delay update, timer reset on rapid changes, non-string types
- [ ] `SignupForm` debounce tests: errors don't show immediately, show after 1500ms, hide immediately on valid input, don't show after clear-then-retype until debounce settles