### PR TITLE
Wipe local store on logout and trigger logout on auth failure

### DIFF
--- a/expo/components/context/AuthUtilsContext.tsx
+++ b/expo/components/context/AuthUtilsContext.tsx
@@ -1,8 +1,8 @@
 import { User } from "@/types/types";
-import http from "@/util/custom-axios";
+import http, { setLogoutCallback } from "@/util/custom-axios";
 import { save, clear } from "@/util/custom-store";
 import axios, { CanceledError, isAxiosError } from "axios";
-import React, { createContext, useContext, useCallback } from "react";
+import React, { createContext, useContext, useCallback, useEffect, useRef } from "react";
 import AsyncStorage from "@react-native-async-storage/async-storage";
 import { useGlobalStore } from "./GlobalStoreContext";
 import { useWebSocket } from "./WebSocketContext";
@@ -29,17 +29,25 @@ const AuthUtilsContext = createContext<AuthUtilsContextType | undefined>(
 );
 
 export const AuthUtilsProvider = (props: { children: React.ReactNode }) => {
-  const { establishConnection, disconnect, connected, acceptInvite } =
-    useWebSocket();
-  const { loadHistoricalMessages } = useMessageStore();
+  const {
+    establishConnection,
+    disconnect,
+    connected,
+    acceptInvite,
+    onAuthFailure,
+    removeAuthFailureHandler,
+  } = useWebSocket();
+  const { loadHistoricalMessages, clearAllMessages } = useMessageStore();
   const {
     user,
     setUser,
     setDeviceId,
     deviceId: globalDeviceId,
     refreshGroups,
+    store,
   } = useGlobalStore();
   const { children } = props;
+  const loggingOutRef = useRef(false);
 
   const handlePendingInvite = useCallback(async () => {
     try {
@@ -213,6 +221,10 @@ export const AuthUtilsProvider = (props: { children: React.ReactNode }) => {
   );
 
   const logout = useCallback(async () => {
+    if (loggingOutRef.current) {
+      return;
+    }
+    loggingOutRef.current = true;
     try {
       // Clear push token BEFORE clearing JWT (request needs auth)
       if (globalDeviceId) {
@@ -226,12 +238,43 @@ export const AuthUtilsProvider = (props: { children: React.ReactNode }) => {
       if (connected) {
         await disconnect();
       }
+      try {
+        await store.clearAll();
+      } catch (storeError) {
+        console.error("Error clearing local store on logout:", storeError);
+      }
+      try {
+        clearAllMessages();
+      } catch (msgError) {
+        console.error("Error clearing in-memory messages on logout:", msgError);
+      }
     } catch (error) {
       console.error("Error during logout:", error);
     } finally {
       router.replace({ pathname: "/(auth)" });
+      loggingOutRef.current = false;
     }
-  }, [setUser, setDeviceId, connected, disconnect, globalDeviceId]);
+  }, [
+    setUser,
+    setDeviceId,
+    connected,
+    disconnect,
+    globalDeviceId,
+    store,
+    clearAllMessages,
+  ]);
+
+  // Register logout as the axios 401 handler and the WebSocket auth-failure
+  // handler so implicit logout paths (expired JWT, server-side rejection) wipe
+  // local state the same way an explicit Settings logout does.
+  useEffect(() => {
+    setLogoutCallback(logout);
+    onAuthFailure(logout);
+    return () => {
+      setLogoutCallback(null);
+      removeAuthFailureHandler(logout);
+    };
+  }, [logout, onAuthFailure, removeAuthFailureHandler]);
 
   return (
     <AuthUtilsContext.Provider value={{ whoami, login, logout, signup }}>

--- a/expo/components/context/MessageStoreContext.tsx
+++ b/expo/components/context/MessageStoreContext.tsx
@@ -23,7 +23,8 @@ type MessageAction =
   | { type: "MERGE_MESSAGES"; payload: DbMessage[] }
   | { type: "REMOVE_GROUP_MESSAGES"; payload: string }
   | { type: "SET_LOADING"; payload: boolean }
-  | { type: "SET_ERROR"; payload: string | null };
+  | { type: "SET_ERROR"; payload: string | null }
+  | { type: "CLEAR_ALL" };
 
 interface MessageState {
   messages: Record<string, DbMessage[]>;
@@ -37,6 +38,7 @@ interface MessageStoreContextType {
   error: string | null;
   loadHistoricalMessages: (deviceId?: string) => Promise<void>;
   removeGroupMessages: (groupId: string) => void;
+  clearAllMessages: () => void;
   optimistic: Record<string, OptimisticMessageItem[]>;
   addOptimisticDisplayable: (item: OptimisticMessageItem) => void;
   removeOptimisticDisplayable: (groupId: string, id: string) => void;
@@ -124,6 +126,8 @@ export const messageReducer = (
       return { ...state, loading: action.payload };
     case "SET_ERROR":
       return { ...state, error: action.payload };
+    case "CLEAR_ALL":
+      return initialState;
     default:
       return state;
   }
@@ -497,6 +501,17 @@ export const MessageStoreProvider: React.FC<{ children: React.ReactNode }> = ({
     []
   );
 
+  const clearAllMessages = useCallback(() => {
+    dispatch({ type: "CLEAR_ALL" });
+    setOptimistic({});
+    optimisticRef.current = {};
+    globalClientSequenceRef.current = 0;
+    hasLoadedHistoricalMessagesRef.current = false;
+    hasPendingSigningKeyRecoveryRef.current = false;
+    lastRecoverySyncAttemptRef.current = 0;
+    clearRecoveryRetryTimeout();
+  }, [clearRecoveryRetryTimeout]);
+
   const value = useMemo(
     () => ({
       getMessagesForGroup,
@@ -504,6 +519,7 @@ export const MessageStoreProvider: React.FC<{ children: React.ReactNode }> = ({
       error: state.error,
       loadHistoricalMessages,
       removeGroupMessages,
+      clearAllMessages,
       optimistic,
       addOptimisticDisplayable,
       removeOptimisticDisplayable,
@@ -515,6 +531,7 @@ export const MessageStoreProvider: React.FC<{ children: React.ReactNode }> = ({
       state.error,
       loadHistoricalMessages,
       removeGroupMessages,
+      clearAllMessages,
       optimistic,
       addOptimisticDisplayable,
       removeOptimisticDisplayable,

--- a/expo/components/context/MessageStoreContext.tsx
+++ b/expo/components/context/MessageStoreContext.tsx
@@ -216,6 +216,7 @@ export const MessageStoreProvider: React.FC<{ children: React.ReactNode }> = ({
   }, [optimistic]);
 
   const isSyncingHistoricalMessagesRef = useRef(false);
+  const syncGenerationRef = useRef(0);
   const lastRecoverySyncAttemptRef = useRef(0);
   const hasPendingSigningKeyRecoveryRef = useRef(false);
   const recoveryRetryTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(
@@ -258,12 +259,18 @@ export const MessageStoreProvider: React.FC<{ children: React.ReactNode }> = ({
       }
 
       isSyncingHistoricalMessagesRef.current = true;
+      const generation = syncGenerationRef.current;
       dispatch({ type: "SET_LOADING", payload: true });
 
       try {
         const response = await http.get<RawMessage[]>(
           `${process.env.EXPO_PUBLIC_HOST}/ws/relevant-messages`
         );
+
+        if (syncGenerationRef.current !== generation) {
+          return;
+        }
+
         const rawMessages: RawMessage[] = response.data;
         const processedMessages: DbMessage[] = [];
         let skippedForMissingSigningKey = 0;
@@ -312,6 +319,10 @@ export const MessageStoreProvider: React.FC<{ children: React.ReactNode }> = ({
         }
         await store.saveMessages(processedMessages, canReplaceSnapshot);
 
+        if (syncGenerationRef.current !== generation) {
+          return;
+        }
+
         // Mark that we've loaded historical messages at least once
         hasLoadedHistoricalMessagesRef.current = true;
 
@@ -323,6 +334,9 @@ export const MessageStoreProvider: React.FC<{ children: React.ReactNode }> = ({
 
         refreshGroups();
       } catch (error) {
+        if (syncGenerationRef.current !== generation) {
+          return;
+        }
         if (!(error instanceof CanceledError)) {
           console.error(
             "loadHistoricalMessages: Failed to sync messages:",
@@ -330,6 +344,9 @@ export const MessageStoreProvider: React.FC<{ children: React.ReactNode }> = ({
           );
           try {
             const messages = await store.loadMessages();
+            if (syncGenerationRef.current !== generation) {
+              return;
+            }
             dispatch({ type: "SET_HISTORICAL_MESSAGES", payload: messages });
             dispatch({
               type: "SET_ERROR",
@@ -349,8 +366,10 @@ export const MessageStoreProvider: React.FC<{ children: React.ReactNode }> = ({
           console.log("loadHistoricalMessages: Sync operation was canceled.");
         }
       } finally {
-        dispatch({ type: "SET_LOADING", payload: false });
-        isSyncingHistoricalMessagesRef.current = false;
+        if (syncGenerationRef.current === generation) {
+          dispatch({ type: "SET_LOADING", payload: false });
+          isSyncingHistoricalMessagesRef.current = false;
+        }
       }
     },
     [
@@ -394,6 +413,7 @@ export const MessageStoreProvider: React.FC<{ children: React.ReactNode }> = ({
         );
         return;
       }
+      const generation = syncGenerationRef.current;
 
       // Find optimistic message to extract client metadata
       const optimisticMsg = optimisticRef.current[rawMsg.group_id]?.find(
@@ -462,8 +482,16 @@ export const MessageStoreProvider: React.FC<{ children: React.ReactNode }> = ({
           });
         }
 
+        if (syncGenerationRef.current !== generation) {
+          return;
+        }
+
         dispatch({ type: "ADD_MESSAGE", payload: processedMessage });
         await store.saveMessages([processedMessage]);
+
+        if (syncGenerationRef.current !== generation) {
+          return;
+        }
 
         refreshGroups();
 
@@ -502,6 +530,8 @@ export const MessageStoreProvider: React.FC<{ children: React.ReactNode }> = ({
   );
 
   const clearAllMessages = useCallback(() => {
+    syncGenerationRef.current += 1;
+    isSyncingHistoricalMessagesRef.current = false;
     dispatch({ type: "CLEAR_ALL" });
     setOptimistic({});
     optimisticRef.current = {};

--- a/expo/components/context/WebSocketContext.tsx
+++ b/expo/components/context/WebSocketContext.tsx
@@ -299,22 +299,20 @@ export const WebSocketProvider: React.FC<{ children: React.ReactNode }> = ({
                 }
               } else if (parsedData.type === "auth_failure") {
                 preventRetriesRef.current = true;
+                socket.close(CLOSE_CODE_AUTH_FAILED, "Authentication Failed");
+                authFailureHandlersRef.current.forEach((handler) => {
+                  Promise.resolve(handler()).catch((handlerError) => {
+                    console.error(
+                      "Error in auth failure handler:",
+                      handlerError,
+                    );
+                  });
+                });
                 safeReject(
                   new Error(
                     `Authentication failed: ${parsedData.error || "Unknown reason"}`,
                   ),
                 );
-                socket.close(CLOSE_CODE_AUTH_FAILED, "Authentication Failed");
-                authFailureHandlersRef.current.forEach((handler) => {
-                  try {
-                    handler();
-                  } catch (handlerError) {
-                    console.error(
-                      "Error in auth failure handler:",
-                      handlerError,
-                    );
-                  }
-                });
               } else {
                 preventRetriesRef.current = true;
                 safeReject(

--- a/expo/components/context/WebSocketContext.tsx
+++ b/expo/components/context/WebSocketContext.tsx
@@ -32,6 +32,8 @@ interface WebSocketContextType {
   removeMessageHandler: (callback: (packet: RawMessage) => void) => void;
   onGroupEvent: (callback: (event: GroupEvent) => void) => void;
   removeGroupEventHandler: (callback: (event: GroupEvent) => void) => void;
+  onAuthFailure: (callback: () => void) => void;
+  removeAuthFailureHandler: (callback: () => void) => void;
   establishConnection: () => Promise<void>;
   disconnect: () => void;
   createGroup: (
@@ -91,6 +93,7 @@ export const WebSocketProvider: React.FC<{ children: React.ReactNode }> = ({
   const [connected, setConnected] = useState(false);
   const messageHandlersRef = useRef<((packet: RawMessage) => void)[]>([]);
   const groupEventHandlersRef = useRef<((event: GroupEvent) => void)[]>([]);
+  const authFailureHandlersRef = useRef<(() => void)[]>([]);
   const isReconnecting = useRef(false);
   const preventRetriesRef = useRef(false);
   const appState = useRef(AppState.currentState);
@@ -302,6 +305,16 @@ export const WebSocketProvider: React.FC<{ children: React.ReactNode }> = ({
                   ),
                 );
                 socket.close(CLOSE_CODE_AUTH_FAILED, "Authentication Failed");
+                authFailureHandlersRef.current.forEach((handler) => {
+                  try {
+                    handler();
+                  } catch (handlerError) {
+                    console.error(
+                      "Error in auth failure handler:",
+                      handlerError,
+                    );
+                  }
+                });
               } else {
                 preventRetriesRef.current = true;
                 safeReject(
@@ -604,6 +617,21 @@ export const WebSocketProvider: React.FC<{ children: React.ReactNode }> = ({
     [],
   );
 
+  const onAuthFailure = useCallback((callback: () => void) => {
+    if (!authFailureHandlersRef.current.includes(callback)) {
+      authFailureHandlersRef.current = [
+        ...authFailureHandlersRef.current,
+        callback,
+      ];
+    }
+  }, []);
+
+  const removeAuthFailureHandler = useCallback((callback: () => void) => {
+    authFailureHandlersRef.current = authFailureHandlersRef.current.filter(
+      (h) => h !== callback,
+    );
+  }, []);
+
   useEffect(() => {
     preventRetriesRef.current = false;
     return () => {
@@ -719,6 +747,8 @@ export const WebSocketProvider: React.FC<{ children: React.ReactNode }> = ({
         removeMessageHandler,
         onGroupEvent,
         removeGroupEventHandler,
+        onAuthFailure,
+        removeAuthFailureHandler,
         establishConnection,
         disconnect,
         createGroup,

--- a/expo/store/Store.ts
+++ b/expo/store/Store.ts
@@ -562,6 +562,18 @@ export class Store implements IStore {
     await db.runAsync("DELETE FROM users;");
   }
 
+  async clearAll(): Promise<void> {
+    return this.performSerialTransaction(async (db) => {
+      // Explicit deletes match the pattern in deleteGroup/deleteExpiredGroups.
+      // group_reads and messages would also cascade from groups, but explicit
+      // deletes avoid relying on PRAGMA foreign_keys remaining enabled.
+      await db.runAsync("DELETE FROM group_reads;");
+      await db.runAsync("DELETE FROM messages;");
+      await db.runAsync("DELETE FROM groups;");
+      await db.runAsync("DELETE FROM users;");
+    });
+  }
+
   async loadMessages(): Promise<DbMessage[]> {
     const db = await this.getDb();
     const result = await db.getAllAsync<MessageRow>(`

--- a/expo/store/types.ts
+++ b/expo/store/types.ts
@@ -38,6 +38,7 @@ export interface IStore {
   markGroupRead(groupId: string): Promise<void>;
   deleteGroup(groupId: string): Promise<void>;
   deleteExpiredGroups(): Promise<string[]>;
+  clearAll(): Promise<void>;
   close(): Promise<void>;
 }
 

--- a/expo/util/custom-axios.js
+++ b/expo/util/custom-axios.js
@@ -4,6 +4,12 @@ import { jwtDecode } from "jwt-decode";
 
 const http = axios.create();
 
+let logoutCallback = null;
+
+export function setLogoutCallback(fn) {
+  logoutCallback = fn;
+}
+
 function isTokenExpired(token) {
   if (!token) {
     return true;
@@ -43,5 +49,19 @@ http.interceptors.request.use(async (config) => {
     signal: controller.signal,
   };
 });
+
+http.interceptors.response.use(
+  (response) => response,
+  (error) => {
+    if (error.response?.status === 401 && logoutCallback) {
+      try {
+        logoutCallback();
+      } catch (callbackError) {
+        console.error("Error in logout callback:", callbackError);
+      }
+    }
+    return Promise.reject(error);
+  },
+);
 
 export default http;

--- a/expo/util/custom-axios.js
+++ b/expo/util/custom-axios.js
@@ -35,12 +35,26 @@ http.interceptors.request.use(async (config) => {
     if (isTokenExpired(token)) {
       console.log("JWT is expired on client-side. Aborting request.");
       await clear("jwt");
+      if (logoutCallback) {
+        try {
+          logoutCallback();
+        } catch (callbackError) {
+          console.error("Error in logout callback:", callbackError);
+        }
+      }
       controller.abort();
     } else {
       config.headers["Authorization"] = `Bearer ${token}`;
     }
   } else {
     console.log("No JWT found. Aborting request.");
+    if (logoutCallback) {
+      try {
+        logoutCallback();
+      } catch (callbackError) {
+        console.error("Error in logout callback:", callbackError);
+      }
+    }
     controller.abort();
   }
 


### PR DESCRIPTION
## Summary
- Adds `Store.clearAll()` and a `CLEAR_ALL` action on `MessageStoreContext`, both invoked from `logout()` so SQLite (groups → cascades to messages and group_reads, plus users) and in-memory state (reducer, optimistic, sequence counter) are reset.
- Adds a 401 axios response interceptor and a WebSocket `onAuthFailure` handler-array (matching the existing `onMessage` / `onGroupEvent` pattern). Both fire the same `logout()`, so an expired JWT or a server-side WS rejection now wipes local state the same way Settings → Log Out does.
- Adds a re-entry guard so a 401 fired during `logout()` (e.g. from `clearPushTokenOnServer` itself) does not recurse, and wraps the new wipe steps in their own try/catch so a SQLite failure cannot strand the user on the authed UI.

This is identifier-agnostic — device-key storage is untouched. Per-user scoping of device keys is deferred to the planned SIWA cutover.

Plan: see `development-notes/clear-local-store-on-logout/three-step-plan.md` (this PR is Step 1).

## Test plan
- [ ] Sign up / log in, create a group, send/receive messages, then Settings → Log Out. Log back in (same or different account). Verify no stale messages or groups appear.
- [ ] Manually expire the stored JWT (e.g. clear it in AsyncStorage debug, or shorten dev expiry). Trigger an authenticated action (e.g. navigate to a screen that calls `whoami`). Expect: 401 → automatic logout → router lands on `(auth)`.
- [ ] Force a WebSocket `auth_failure` (restart the server with a new `JWT_SECRET`, then reconnect). Expect: WS closes → automatic logout → router lands on `(auth)`.
- [ ] During `clearPushTokenOnServer` mid-flight, simulate a 401 response. Expect only one logout chain to execute (no double wipes, no navigation race).
- [ ] `npx tsc --noEmit` from `expo/` introduces no new errors (existing 25 errors are all in pre-existing test fixtures).
- [ ] `npx eslint` clean on the six touched files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented duplicate logout attempts during session termination
  * Enhanced handling of authentication failures on WebSocket connections

* **Improvements**
  * Strengthened session cleanup by ensuring all stored data, messages, and application state are fully cleared on logout
  * Improved logout callback registration for more reliable session management

<!-- end of auto-generated comment: release notes by coderabbit.ai -->