### PR TITLE
Include requesting user in GetRelevantUserDeviceKeys

### DIFF
--- a/db/queries/user_queries.sql
+++ b/db/queries/user_queries.sql
@@ -68,6 +68,11 @@ relevant_users AS (
     SELECT DISTINCT ug.user_id
     FROM user_groups ug
     JOIN user_target_groups utg ON ug.group_id = utg.group_id
+    UNION
+    -- Always include the requesting user so a fresh user with no groups
+    -- still gets their own device keys (needed to encrypt to themselves
+    -- when they create their first group).
+    SELECT $1::uuid
 )
 SELECT
     ru.user_id,

--- a/server/db/user_queries.sql.go
+++ b/server/db/user_queries.sql.go
@@ -170,6 +170,11 @@ relevant_users AS (
     SELECT DISTINCT ug.user_id
     FROM user_groups ug
     JOIN user_target_groups utg ON ug.group_id = utg.group_id
+    UNION
+    -- Always include the requesting user so a fresh user with no groups
+    -- still gets their own device keys (needed to encrypt to themselves
+    -- when they create their first group).
+    SELECT $1::uuid
 )
 SELECT
     ru.user_id,


### PR DESCRIPTION
## Summary

A user with no groups got an empty result from `GetRelevantUserDeviceKeys` — including their own device keys — because `relevant_users` was built solely by joining `user_groups` against the requester's groups. That broke sending in their first group: `useSendMessage` looks up the recipient's pubkey (including self) in `relevantDeviceKeys`, the lookup returned undefined, and the user saw "No valid recipient device keys found".

Add a `UNION SELECT $1::uuid` so the requesting user is always in `relevant_users`, regardless of group membership.

## Test plan
- [ ] `make dev-up && make expo-start`
- [ ] Sign up as a new user → create a first group → send a message → succeeds (no "No valid recipient device keys found" error)
- [ ] Existing user with groups: send messages still work, recipient list still includes group members
- [ ] `docker compose logs -f go-server` shows no errors on the device-keys endpoint